### PR TITLE
Fix: Kirby closure needs default argument

### DIFF
--- a/readingtime/readingtime.php
+++ b/readingtime/readingtime.php
@@ -45,6 +45,6 @@ function readingtime($content, $params = array()) {
 
 }
 
-field::$methods['readingtime'] = function($field, $params) {
+field::$methods['readingtime'] = function($field, $params = array()) {
   return readingtime($field->value, $params);
 };


### PR DESCRIPTION
When using the plugin like suggested:

```
<?php echo $page->text()->readingtime() ?>
```

This error is returned:
```
Missing argument 2 for Kirby::{closure}()
```

I set the closure argument to an empty array to fix this.