### PR TITLE
Alternative format option

### DIFF
--- a/readingtime/readingtime.php
+++ b/readingtime/readingtime.php
@@ -11,7 +11,7 @@
  * <?php echo $page->text()->readingtime() ?>
  *
  * @author Roy Lodder <http://roylodder.com>, Bastian Allgeier <http://getkirby.com>
- * @version 2.0.1
+ * @version 2.1.0
  */
 function readingtime($content, $params = array()) {
 
@@ -22,7 +22,7 @@ function readingtime($content, $params = array()) {
     'seconds'             => 'seconds',
     'format'              => '{minutesCount} {minutesLabel}, {secondsCount} {secondsLabel}',
     'format-alt'          => '{secondsCount} {secondsLabel}',
-    'enable-alt-format'   => true
+    'enable-alt-format'   => false
   );
 
   $options      = array_merge($defaults, $params);

--- a/readingtime/readingtime.php
+++ b/readingtime/readingtime.php
@@ -21,8 +21,8 @@ function readingtime($content, $params = array()) {
     'second'              => 'second',
     'seconds'             => 'seconds',
     'format'              => '{minutesCount} {minutesLabel}, {secondsCount} {secondsLabel}',
-    'format-alt'          => '{secondsCount} {secondsLabel}',
-    'enable-alt-format'   => false
+    'format.alt'          => '{secondsCount} {secondsLabel}',
+    'format.alt.enable'   => false
   );
 
   $options      = array_merge($defaults, $params);
@@ -38,8 +38,8 @@ function readingtime($content, $params = array()) {
     'secondsLabel' => $secondsLabel,
   );
 
-  if ($minutesCount < 1 and $options['enable-alt-format'] === true ) {
-    $result = $options['format-alt'];
+  if ($minutesCount < 1 and $options['format.alt.enable'] === true ) {
+    $result = $options['format.alt'];
   } else {
     $result = $options['format'];
   }

--- a/readingtime/readingtime.php
+++ b/readingtime/readingtime.php
@@ -11,16 +11,18 @@
  * <?php echo $page->text()->readingtime() ?>
  *
  * @author Roy Lodder <http://roylodder.com>, Bastian Allgeier <http://getkirby.com>
- * @version 2.0.0
+ * @version 2.0.1
  */
 function readingtime($content, $params = array()) {
 
   $defaults = array(
-    'minute'  => 'minute',
-    'minutes' => 'minutes',
-    'second'  => 'second',
-    'seconds' => 'seconds',
-    'format'  => '{minutesCount} {minutesLabel}, {secondsCount} {secondsLabel}'
+    'minute'              => 'minute',
+    'minutes'             => 'minutes',
+    'second'              => 'second',
+    'seconds'             => 'seconds',
+    'format'              => '{minutesCount} {minutesLabel}, {secondsCount} {secondsLabel}',
+    'format-alt'          => '{secondsCount} {secondsLabel}',
+    'enable-alt-format'   => true
   );
 
   $options      = array_merge($defaults, $params);
@@ -36,7 +38,12 @@ function readingtime($content, $params = array()) {
     'secondsLabel' => $secondsLabel,
   );
 
-  $result = $options['format'];
+  if ($minutesCount < 1 and $options['enable-alt-format'] === true ) {
+    $result = $options['format-alt'];
+  } else {
+    $result = $options['format'];
+  }
+
   foreach($replace as $key => $value) {
     $result = str_replace('{' . $key . '}', $value, $result);
   }

--- a/readingtime/readme.md
+++ b/readingtime/readme.md
@@ -63,8 +63,8 @@ You also can enable an alternative format that hides the minute label. This come
 
     echo $page->text()->readingtime(array(
         'format' => '{minutesCount} {minutesLabel}, {secondsCount} {secondsLabel}',
-        'format-alt' => '{secondsCount} {secondsLabel}',
-        'enable-alt-format' => true
+        'format.alt' => '{secondsCount} {secondsLabel}',
+        'format.alt.enable' => true
     ));
 
     ?>

--- a/readingtime/readme.md
+++ b/readingtime/readme.md
@@ -57,6 +57,18 @@ You can even change the entire format of the result:
 
 	?>
 
+You also can enable an alternative format that hides the minute label. This comes in handy if you have content that you can read under a minute.
+
+    <?php
+
+    echo $page->text()->readingtime(array(
+        'format' => '{minutesCount} {minutesLabel}, {secondsCount} {secondsLabel}',
+        'format-alt' => '{secondsCount} {secondsLabel}',
+        'enable-alt-format' => true
+    ));
+
+    ?>
+
 ## Authors
 
 Author: Roy Lodder <http://roylodder.com>


### PR DESCRIPTION
Last week someone asked me to add an option that enables an alternative format that hides the minute label when you can read the content under a minute. I added it in such way that it is backwards-compatible. Let me know what you think about this. 