### PR TITLE
Ability to generate an empty RSS feed

### DIFF
--- a/feed/feed.php
+++ b/feed/feed.php
@@ -36,8 +36,11 @@ Pages::$methods['feed'] = function($pages, $params = array()) {
   // fetch the modification date
   if($options['datefield'] == 'modified') {
     $options['modified'] = $items->first()->modified();
-  } else {
+  } else if( $items->count() > 0 ) {
     $options['modified'] = $items->first()->date(false, $options['datefield']);
+  } else {
+    // there are no items in this feed
+    // so keep the default modification date
   }
 
   // send the xml header


### PR DESCRIPTION
When you try to call 'feed' on an empty collection of Pages, feed.php throws an error as it tries to access the date of the first Page without checking that there are any Pages.

This fix adds that check and lets the 'modified' option take the default value of 'time()' if the feed is empty.