### PR TITLE
Fixing variable reference in JS handler

### DIFF
--- a/cachebuster/cachebuster.php
+++ b/cachebuster/cachebuster.php
@@ -23,7 +23,7 @@ $kirby->options['css.handler'] = function($url, $media = false) use($cssHandler,
 
 };
 
-$kirby->options['js.handler'] = function($src, $async = false) use($jsHandler) {
+$kirby->options['js.handler'] = function($src, $async = false) use($jsHandler, $kirby) {
 
   if(is_array($src)) {
     $js = array();
@@ -31,11 +31,11 @@ $kirby->options['js.handler'] = function($src, $async = false) use($jsHandler) {
     return implode(PHP_EOL, $js) . PHP_EOL;
   }
 
-  $file = $kirby->roots()->index() . DS . $url;
+  $file = $kirby->roots()->index() . DS . $src;
 
   if(file_exists($file)) {
     $mod = f::modified($file);
-    $url = dirname($url) . '/' . f::name($url) . '.' . $mod . '.js';
+    $url = dirname($src) . '/' . f::name($src) . '.' . $mod . '.js';
   }
 
   return call($jsHandler, array($src, $async));

--- a/cachebuster/cachebuster.php
+++ b/cachebuster/cachebuster.php
@@ -40,6 +40,6 @@ $kirby->options['js.handler'] = function($src, $async = false) use($jsHandler, $
     $url = dirname($src) . '/' . f::name($src) . '.' . $mod . '.js';
   }
 
-  return call($jsHandler, array($src, $async));
+  return call($jsHandler, array($url, $async));
 
 };

--- a/cachebuster/cachebuster.php
+++ b/cachebuster/cachebuster.php
@@ -1,5 +1,7 @@
 <?php 
 
+if(!c::get('cachebuster')) return;
+
 $kirby      = kirby();
 $cssHandler = kirby()->option('css.handler');
 $jsHandler  = kirby()->option('js.handler');

--- a/cachebuster/cachebuster.php
+++ b/cachebuster/cachebuster.php
@@ -37,9 +37,9 @@ $kirby->options['js.handler'] = function($src, $async = false) use($jsHandler, $
 
   if(file_exists($file)) {
     $mod = f::modified($file);
-    $url = dirname($src) . '/' . f::name($src) . '.' . $mod . '.js';
+    $src = dirname($src) . '/' . f::name($src) . '.' . $mod . '.js';
   }
 
-  return call($jsHandler, array($url, $async));
+  return call($jsHandler, array($src, $async));
 
 };

--- a/cachebuster/readme.md
+++ b/cachebuster/readme.md
@@ -3,8 +3,10 @@
 This plugin will add modification timestamps to your css and js files, 
 as long as they are embedded with the css() and js() helpers.
 
-To make this plugin work you must add the following lines to your 
-rewrite rules:
+## htaccess rules for Apache
+
+To make this plugin work on Apache you must add the following lines to your 
+htaccess file:
 
 ```
 RewriteCond %{REQUEST_FILENAME} !-f
@@ -12,6 +14,18 @@ RewriteRule ^(.+)\.(\d+)\.(js|css)$ $1.$3 [L]
 ```
 
 Place them directly after the RewriteBase definition.
+
+## Nginx rewrite rules
+
+For Nginx you can add the following to your virtual host setup:
+
+```
+location /assets {
+  if (!-e $request_filename) {
+    rewrite ^/(.+)\.(\d+)\.(js|css)$ /$1.$3 break;
+  }
+}
+```
 
 ## Author
 Bastian Allgeier <bastian@getkirby.com>

--- a/cdn/cdn.php
+++ b/cdn/cdn.php
@@ -1,0 +1,31 @@
+<?php 
+
+if(c::get('cdn.content')) {
+  kirby()->urls()->content = c::get('cdn.content');  
+}
+
+if(c::get('cdn.thumbs')) {  
+  thumb::$defaults['url'] = c::get('cdn.thumbs');
+}
+
+if(c::get('cdn.assets')) {
+
+  $original = url::$to;
+
+  url::$to = function() use($original) {
+
+    $url = call($original, func_get_args());
+
+    if(!str::startsWith($url, kirby()->urls()->index())) {
+      return $url;
+    }
+
+    $url = preg_replace_callback('!.*?\/assets\/(.*)$!', function($match) {
+      return c::get('cdn.assets') . '/' . $match[1];
+    }, $url);
+
+    return $url;
+
+  };
+
+}

--- a/cdn/readme.md
+++ b/cdn/readme.md
@@ -1,0 +1,45 @@
+# Kirby CDN Plugin
+
+This plugin will rewrite all URLs to assets, files in the content folder and thumbnails to direct to a CDN. 
+
+## Setup 
+
+1. Copy the cdn folder into site/plugins
+2. Add the following config options to site/config/config.php
+
+```php
+c::set('cdn.assets', 'http://cdn.mydomain.com');
+c::set('cdn.content', 'http://cdn.mydomain.com');
+c::set('cdn.thumbs', 'http://cdn.mydomain.com');
+```
+
+That's it! Make sure you have a CDN at that url at all :) and it either has all the assets you are linking to uploaded, or it is setup as a pullzone.
+
+You can switch off parts of it by simply passing false or not setting it: 
+
+```
+c::set('cdn.thumbs', false);
+```
+
+Or you can of course use different CDNs or subdomains:
+
+```php
+c::set('cdn.assets', 'http://assets.mycdn.com');
+c::set('cdn.content', 'http://content.mycdn.com');
+c::set('cdn.thumbs', 'http://thumbs.mycdn.com');
+```
+
+## Cachebusting
+
+In addition to the CDN plugin you might want to check out the cachebuster plugin to help you with cachebusting for CSS or JS files in order to avoid issues with cached assets after updates. 
+
+## Beware with thumbs!
+
+Enabling the CDN option for thumbnails might easily eat up your storage limit on your CDN unless your assets automatically expire after a certain time, because old thumbnails won't be deleted automatically. 
+
+## Tested
+
+This plugin has so far only been tested with <http://keycdn.com>. Please let me know if you run into any issues with other CDNs and feel free to submit improvements. 
+
+## Author
+Bastian Allgeier <bastian@getkirby.com> 


### PR DESCRIPTION
The incorrect variable was being used to return the 'cachebusted' path. Using `$src` returns the original path, whereas `$url` returns the proper 'cachebusted' path.

Edit: The original pull request had an oversight. The latest commit now ensures that `$src` is being used throughout the entire handler function.