### PR TITLE
Fix Panel Assets Issue

### DIFF
--- a/cdn/cdn.php
+++ b/cdn/cdn.php
@@ -15,11 +15,14 @@ if(c::get('cdn.assets')) {
   url::$to = function() use($original) {
 
     $url = call($original, func_get_args());
+  
 
     if(!str::startsWith($url, kirby()->urls()->index())) {
       return $url;
     }
-
+    if(str::contains($url, '/panel/assets')) {
+      return $url;
+    }
     $url = preg_replace_callback('!.*?\/assets\/(.*)$!', function($match) {
       return c::get('cdn.assets') . '/' . $match[1];
     }, $url);

--- a/cdn/cdn.php
+++ b/cdn/cdn.php
@@ -19,9 +19,11 @@ if(c::get('cdn.assets')) {
     if(!str::startsWith($url, kirby()->urls()->index())) {
       return $url;
     }
+
     if(str::contains($url, '/panel/assets')) {
       return $url;
     }
+    
     $url = preg_replace_callback('!.*?\/assets\/(.*)$!', function($match) {
       return c::get('cdn.assets') . '/' . $match[1];
     }, $url);

--- a/cdn/cdn.php
+++ b/cdn/cdn.php
@@ -15,7 +15,6 @@ if(c::get('cdn.assets')) {
   url::$to = function() use($original) {
 
     $url = call($original, func_get_args());
-  
 
     if(!str::startsWith($url, kirby()->urls()->index())) {
       return $url;


### PR DESCRIPTION
This PR fixes an issue where the panel assets would wrongly get the `cdn.assets` url.

Eventually there could be a `cdn.panel` option to set a panel-specific cdn. 