### PR TITLE
Fix #21: Feed plugin timestamp error

### DIFF
--- a/feed/feed.php
+++ b/feed/feed.php
@@ -37,7 +37,7 @@ Pages::$methods['feed'] = function($pages, $params = array()) {
   if($options['datefield'] == 'modified') {
     $options['modified'] = $items->first()->modified();
   } else {
-    $options['modified'] = $items->first()->date(false, $options['datefield']);
+    $options['modified'] = $items->first()->date(null, $options['datefield']);
   }
 
   // send the xml header


### PR DESCRIPTION
Since getkirby/kirby@78473d149d42f4d9abe76981078b93ee62cff488, the `date()` method actually checks for a `null` value, so `false` does not work here.